### PR TITLE
Fixed long literals with quantifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rgx"
-version = "1.1.1"
+version = "1.2.0"
 description = "Typed, simple and readable regexp generation"
 authors = ["Dmitry Gritsenko <k01419q45@ya.ru>"]
 license = "MIT"

--- a/rgx/entities.py
+++ b/rgx/entities.py
@@ -598,6 +598,8 @@ class ConditionalPattern(RegexPattern):
 class Literal(RegexPattern):
     def __init__(self, contents: str) -> None:
         self.contents: str = contents
+        if len(self.contents) != 1:
+            self.priority = 2
 
     def render(self) -> StrGen:
         yield re.escape(self.contents)

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -61,7 +61,7 @@ class TestClass:
         assert ((a | b) + b).render_str() == "(?:a|b)b"
         assert ((a + b) | b).render_str() == "ab|b"
         assert a.many().many().render_str() == "(?:a+)+"
-        assert (a + b).many().render_str() == "(ab)+"
+        assert (a + b).many().render_str() == "(?:ab)+"
 
     def test_flags(self):
         assert a.set_flags("i").render_str() == "(?i:a)"

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -61,6 +61,7 @@ class TestClass:
         assert ((a | b) + b).render_str() == "(?:a|b)b"
         assert ((a + b) | b).render_str() == "ab|b"
         assert a.many().many().render_str() == "(?:a+)+"
+        assert (a + b).many().render_str() == "(ab)+"
 
     def test_flags(self):
         assert a.set_flags("i").render_str() == "(?i:a)"


### PR DESCRIPTION
Now long (length more than 1) literals have a lower priority to be wrapped in parens when quantified